### PR TITLE
Add coverage folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ public/app.js
 .floobit
 .floo
 .flooignore
+
+# Testing
+coverage


### PR DESCRIPTION
Minor fix so that we can run coverage tests and not worry about committing the output.