### PR TITLE
53 refactor modal form - subwidget complete

### DIFF
--- a/client/components/QnAs/Feedback.jsx
+++ b/client/components/QnAs/Feedback.jsx
@@ -1,1 +1,0 @@
-import React from 'react';

--- a/client/components/QnAs/HelpfulReport.jsx
+++ b/client/components/QnAs/HelpfulReport.jsx
@@ -10,7 +10,7 @@ class HelpfulReport extends React.Component {
       reported: false,
       helpfulClicked: false,
       reportText: 'Report',
-      helpVotes: this.props.helpVotes,
+      helpVotes: 0,
       showModal: false,
     };
     this.report = this.report.bind(this);
@@ -27,7 +27,7 @@ class HelpfulReport extends React.Component {
       });
       axios
         .put(
-          `http://localhost:3000/api/fec2/hrnyc/qa/questions/${this.props.id}/report`
+          `/api/fec2/hrnyc/qa/questions/${this.props.id}/report`
         )
         .then(function (response) {})
         .catch(function (error) {
@@ -35,15 +35,16 @@ class HelpfulReport extends React.Component {
         });
     }
   }
+
   clickHelpful() {
     if (!this.state.helpfulClicked) {
       this.setState({
-        helpVotes: this.state.helpVotes + 1,
+        helpVotes: this.props.helpVotes + 1,
         helpfulClicked: true,
       });
       axios
         .put(
-          `http://localhost:3000/api/fec2/hrnyc/qa/questions/${this.props.id}/helpful`
+          `/api/fec2/hrnyc/qa/questions/${this.props.id}/helpful`
         )
         .then(function (response) {})
         .catch(function (error) {
@@ -57,6 +58,11 @@ class HelpfulReport extends React.Component {
 
   handleCloseModal() {
     this.setState({ showModal: false });
+  }
+  componentDidMount() {
+    this.setState({
+      helpVotes: this.props.helpVotes
+    });
   }
 
   render() {

--- a/client/components/QnAs/HelpfulReport.jsx
+++ b/client/components/QnAs/HelpfulReport.jsx
@@ -13,9 +13,12 @@ class HelpfulReport extends React.Component {
       helpfulClicked: false,
       reportText: 'Report',
       helpVotes: this.props.helpVotes,
+      showModal: false
     };
     this.report = this.report.bind(this);
     this.clickHelpful = this.clickHelpful.bind(this);
+    this.addAnswer = this.addAnswer.bind(this);
+    this.handleCloseModal = this.handleCloseModal.bind(this);
   }
 
 
@@ -47,8 +50,15 @@ class HelpfulReport extends React.Component {
       .catch(function (error) {
         console.log(error);
       });
-
     }
+  }
+  addAnswer() {
+    console.log('addAnswer');
+    this.setState({ showModal: true });
+  }
+
+  handleCloseModal () {
+    this.setState({ showModal: false });
   }
 
   render() {
@@ -61,7 +71,7 @@ class HelpfulReport extends React.Component {
           {!this.props.answerUsage &&
             <div>
               <a
-                onClick={this.report}
+                onClick={this.addAnswer}
                 >Add Answer
               </a>
               <div>

--- a/client/components/QnAs/HelpfulReport.jsx
+++ b/client/components/QnAs/HelpfulReport.jsx
@@ -62,6 +62,9 @@ class HelpfulReport extends React.Component {
   }
 
   render() {
+    // if (this.props.answerUsage) {
+    //   console.log('HR this.props.prodName', this.props.prodName);
+    // }
     return (
       <div>
         <div>
@@ -79,6 +82,9 @@ class HelpfulReport extends React.Component {
                   isOpen={this.state.showModal}
                   handleCloseModal={this.handleCloseModal}
                   id={this.props.id}
+                  question={false}
+                  prodName={this.props.prodName}
+                  question_body={this.props.question_body}
                 />
               </div>
             </div>

--- a/client/components/QnAs/HelpfulReport.jsx
+++ b/client/components/QnAs/HelpfulReport.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import axios from 'axios';
+import Modal from 'react-modal';
+import ModalComp from './ModalComp';
+
+
 
 class HelpfulReport extends React.Component {
   constructor(props) {
@@ -9,11 +13,11 @@ class HelpfulReport extends React.Component {
       helpfulClicked: false,
       reportText: 'Report',
       helpVotes: this.props.helpVotes,
-      // answerUsage: this.props.answerUsage
     };
     this.report = this.report.bind(this);
     this.clickHelpful = this.clickHelpful.bind(this);
   }
+
 
   report() {
     if (!this.state.reported) {
@@ -54,7 +58,21 @@ class HelpfulReport extends React.Component {
           Helpful?
           <a onClick={this.clickHelpful}> | Yes ({this.state.helpVotes}) | </a>
           {this.props.answerUsage && <a onClick={this.report}>{this.state.reportText}</a>}
-          {!this.props.answerUsage && <a onClick={this.report}>add a question</a>}
+          {!this.props.answerUsage &&
+            <div>
+              <a
+                onClick={this.report}
+                >Add Answer
+              </a>
+              <div>
+                <ModalComp
+                  isOpen={this.state.showModal}
+                  handleCloseModal={this.handleCloseModal}
+                  id={this.props.id}
+                />
+              </div>
+            </div>
+          }
         </div>
       </div>
     );

--- a/client/components/QnAs/HelpfulReport.jsx
+++ b/client/components/QnAs/HelpfulReport.jsx
@@ -3,8 +3,6 @@ import axios from 'axios';
 import Modal from 'react-modal';
 import ModalComp from './ModalComp';
 
-
-
 class HelpfulReport extends React.Component {
   constructor(props) {
     super(props);
@@ -13,7 +11,7 @@ class HelpfulReport extends React.Component {
       helpfulClicked: false,
       reportText: 'Report',
       helpVotes: this.props.helpVotes,
-      showModal: false
+      showModal: false,
     };
     this.report = this.report.bind(this);
     this.clickHelpful = this.clickHelpful.bind(this);
@@ -21,20 +19,20 @@ class HelpfulReport extends React.Component {
     this.handleCloseModal = this.handleCloseModal.bind(this);
   }
 
-
   report() {
     if (!this.state.reported) {
       this.setState({
         reportText: 'Reported',
         reported: true,
       });
-      axios.put(`http://localhost:3000/api/fec2/hrnyc/qa/questions/${this.props.id}/report`)
-      .then(function (response) {
-        // console.log(response);
-      })
-      .catch(function (error) {
-        console.log(error);
-      });
+      axios
+        .put(
+          `http://localhost:3000/api/fec2/hrnyc/qa/questions/${this.props.id}/report`
+        )
+        .then(function (response) {})
+        .catch(function (error) {
+          console.log(error);
+        });
     }
   }
   clickHelpful() {
@@ -43,40 +41,36 @@ class HelpfulReport extends React.Component {
         helpVotes: this.state.helpVotes + 1,
         helpfulClicked: true,
       });
-      axios.put(`http://localhost:3000/api/fec2/hrnyc/qa/questions/${this.props.id}/helpful`)
-      .then(function (response) {
-        // console.log(response);
-      })
-      .catch(function (error) {
-        console.log(error);
-      });
+      axios
+        .put(
+          `http://localhost:3000/api/fec2/hrnyc/qa/questions/${this.props.id}/helpful`
+        )
+        .then(function (response) {})
+        .catch(function (error) {
+          console.log(error);
+        });
     }
   }
   addAnswer() {
-    console.log('addAnswer');
     this.setState({ showModal: true });
   }
 
-  handleCloseModal () {
+  handleCloseModal() {
     this.setState({ showModal: false });
   }
 
   render() {
-    // if (this.props.answerUsage) {
-    //   console.log('HR this.props.prodName', this.props.prodName);
-    // }
     return (
       <div>
         <div>
           Helpful?
           <a onClick={this.clickHelpful}> | Yes ({this.state.helpVotes}) | </a>
-          {this.props.answerUsage && <a onClick={this.report}>{this.state.reportText}</a>}
-          {!this.props.answerUsage &&
+          {this.props.answerUsage && (
+            <a onClick={this.report}>{this.state.reportText}</a>
+          )}
+          {!this.props.answerUsage && (
             <div>
-              <a
-                onClick={this.addAnswer}
-                >Add Answer
-              </a>
+              <a onClick={this.addAnswer}>Add Answer</a>
               <div>
                 {/* this modal is for submitting a new answer */}
                 <ModalComp
@@ -87,11 +81,10 @@ class HelpfulReport extends React.Component {
                   prodName={this.props.prodName}
                   question_body={this.props.question_body}
                   question_id={this.props.question_id}
-
                 />
               </div>
             </div>
-          }
+          )}
         </div>
       </div>
     );

--- a/client/components/QnAs/HelpfulReport.jsx
+++ b/client/components/QnAs/HelpfulReport.jsx
@@ -9,6 +9,7 @@ class HelpfulReport extends React.Component {
       helpfulClicked: false,
       reportText: 'Report',
       helpVotes: this.props.helpVotes,
+      // answerUsage: this.props.answerUsage
     };
     this.report = this.report.bind(this);
     this.clickHelpful = this.clickHelpful.bind(this);
@@ -52,7 +53,8 @@ class HelpfulReport extends React.Component {
         <div>
           Helpful?
           <a onClick={this.clickHelpful}> | Yes ({this.state.helpVotes}) | </a>
-          <a onClick={this.report}>{this.state.reportText}</a>
+          {this.props.answerUsage && <a onClick={this.report}>{this.state.reportText}</a>}
+          {!this.props.answerUsage && <a onClick={this.report}>add a question</a>}
         </div>
       </div>
     );

--- a/client/components/QnAs/HelpfulReport.jsx
+++ b/client/components/QnAs/HelpfulReport.jsx
@@ -78,6 +78,7 @@ class HelpfulReport extends React.Component {
                 >Add Answer
               </a>
               <div>
+                {/* this modal is for submitting a new answer */}
                 <ModalComp
                   isOpen={this.state.showModal}
                   handleCloseModal={this.handleCloseModal}
@@ -85,6 +86,8 @@ class HelpfulReport extends React.Component {
                   question={false}
                   prodName={this.props.prodName}
                   question_body={this.props.question_body}
+                  question_id={this.props.question_id}
+
                 />
               </div>
             </div>

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -59,7 +59,7 @@ class ModalComp extends React.Component {
 
   submit() {
     //default to post a QUESTION
-    var reqUrl = 'http://localhost:3000/api/fec2/hrnyc/qa/questions';
+    var reqUrl = '/api/fec2/hrnyc/qa/questions';
     var reqParams = {
       'body': this.state.formBody,
       'name': this.state.formNickname,
@@ -68,7 +68,7 @@ class ModalComp extends React.Component {
     };
     //unless were posting an answer
     if (!this.props.question) {
-      reqUrl = `http://localhost:3000/api/fec2/hrnyc/qa/questions/${this.props.question_id}/answers`;
+      reqUrl = `/api/fec2/hrnyc/qa/questions/${this.props.question_id}/answers`;
       delete reqParams['product_id'];
     }
     axios
@@ -141,56 +141,58 @@ class ModalComp extends React.Component {
           isOpen={this.props.isOpen}
           contentLabel='Minimal Modal Example'
         >
-          {this.props.question ? (
-            <div>
+          <label>
+            {this.props.question ? (
               <div>
-                <h1>Ask Your Question</h1>
-                <h4>About the {this.props.prodName}</h4>
+                <div>
+                  <h1>Ask Your Question</h1>
+                  <h4>About the {this.props.prodName}</h4>
+                </div>
+                <br></br>
+                <div>
+                  <label>* Your Question (Mandatory)</label>
+                </div>
               </div>
-              <br></br>
+            ) : (
               <div>
-                <div>* Your Question (Mandatory)</div>
+                <div>
+                  <h1>Submit Your Answer</h1>
+                  <h4>
+                    {this.props.prodName} : {this.props.question_body}
+                  </h4>
+                </div>
+                <br></br>
+                <div>
+                  <label>* Your Answer (Mandatory)</label>
+                </div>
+              </div>
+            )}
+            <div>
+              <textarea
+                name='message'
+                style={{ width: '400px', height: '200px' }}
+                type='text'
+                onChange={this.handleQuestionInput}
+                maxLength='1000'
+              />
+            </div>
+            <br></br>
+            <div>
+              <label>* What is your nickname (Mandatory)</label>
+              <input
+                type='text'
+                onChange={this.handleNickmameInput}
+                placeholder='Example: jackson11!'
+                maxLength='60'
+              />
+              <div>
+                For privacy reasons, do not use your full name or email address
               </div>
             </div>
-          ) : (
-            <div>
-              <div>
-                <h1>Submit Your Answer</h1>
-                <h4>
-                  {this.props.prodName} : {this.props.question_body}
-                </h4>
-              </div>
-              <br></br>
-              <div>
-                <div>* Your Answer (Mandatory)</div>
-              </div>
-            </div>
-          )}
-          <div>
-            <textarea
-              name='message'
-              style={{ width: '400px', height: '200px' }}
-              type='text'
-              onChange={this.handleQuestionInput}
-              maxLength='1000'
-            />
-          </div>
+          </label>
           <br></br>
           <div>
-            <div>* What is your nickname (Mandatory)</div>
-            <input
-              type='text'
-              onChange={this.handleNickmameInput}
-              placeholder='Example: jackson11!'
-              maxLength='60'
-            />
-            <div>
-              For privacy reasons, do not use your full name or email address
-            </div>
-          </div>
-          <br></br>
-          <div>
-            <div>* Your email (Mandatory)</div>
+            <label>* Your email (Mandatory)</label>
             <input
               type='text'
               onChange={this.handleEmailInput}

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import axios from 'axios';
+import Modal from 'react-modal';
+import SearchQs from './SearchQs';
+import QAList from './QAList';
+
+
+class ModalComp extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      newQnickname: '',
+      newQtext: '',
+      newQemail: '',
+      newQphotos: [],
+      showModal: false
+    };
+
+    this.handleNickmameInput = this.handleNickmameInput.bind(this);
+    this.handleQuestionInput = this.handleQuestionInput.bind(this);
+    this.handleEmailInput = this.handleEmailInput.bind(this);
+    this.submit = this.submit.bind(this);
+  }
+
+
+  handleQuestionInput(e) {
+    var text = e.target.value;
+    this.setState({
+      newQtext: text
+    });
+    e.preventDefault();
+  }
+
+  handleNickmameInput(e) {
+    this.setState({
+      newQnickname: e.target.value
+    });
+    e.preventDefault();
+  }
+
+  handleEmailInput(e) {
+    this.setState({
+      newQemail: e.target.value
+    });
+    e.preventDefault();
+
+  }
+
+  submit(e) {
+    axios.post('http://localhost:3000/api/fec2/hrnyc/qa/questions', {
+      params: {
+        'body': this.state.newQtext,
+        'name': this.state.newQnickname,
+        'email': this.state.newQemail,
+        'product_id': this.props.id
+      }
+    })
+      .then(()=>{
+        this.setState({
+          showModal: false,
+          newQnickname: '',
+          newQtext: '',
+          newQemail: ''
+        });
+        // this.handleCloseModal();
+
+      })
+      .catch((err) => {
+        console.error(err);
+        this.setState({
+          showModal: false,
+          newQnickname: '',
+          newQtext: '',
+          newQemail: ''
+        });
+        // this.handleCloseModal();
+      });
+      this.props.handleCloseModal();
+      e.preventDefault();
+
+  }
+
+  render() {
+    return (
+      <div>
+          <Modal
+           isOpen={this.props.isOpen}
+           contentLabel="Minimal Modal Example"
+          >
+            <button onClick={this.props.handleCloseModal}>Close Modal</button>
+            <input type="text" onChange={this.handleQuestionInput} placeholder='Your Question' />
+            <input type="text" onChange={this.handleNickmameInput} placeholder='Nickname'/>
+            <input type="text" onChange={this.handleEmailInput} placeholder='email'/>
+            <button onClick={this.submit}>Submit</button>
+
+          </Modal>
+      </div>
+    );
+  }
+}
+
+export default ModalComp;

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -98,9 +98,8 @@ class ModalComp extends React.Component {
   }
 
   testForm(e) {
-    console.log('test form');
     var fieldsObj = {
-      'form body': this.state.formBody,
+      Question: this.state.formBody,
       Nickname: this.state.formNickname,
       Email: this.state.formEmail,
     };
@@ -110,9 +109,11 @@ class ModalComp extends React.Component {
         emptyFields.push(key);
       }
     }
+    if (!this.props.question) {
+      emptyFields.splice(0, 1, 'Answer');
+    }
     var emptyAlertText = emptyFields.join(', ');
     if (emptyFields.length > 0) {
-      console.log('empty alert text', emptyAlertText);
       alert('You must enter the following: ' + emptyAlertText);
     } else if (!this.validateEmail(this.state.formEmail)) {
       alert('Please enter a valid email address');

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -58,15 +58,21 @@ class ModalComp extends React.Component {
   }
 
   submit() {
-    axios
-    //this is built out to POST a new question, need to build POST answer logic
-      .post('http://localhost:3000/api/fec2/hrnyc/qa/questions', {
-        params: {
-          'body': this.state.formBody,
-          'name': this.state.formNickname,
-          'email': this.state.formEmail,
-          'product_id': this.props.id,
-        },
+    //default to post a QUESTION
+    var reqUrl = 'http://localhost:3000/api/fec2/hrnyc/qa/questions';
+    var reqParams = {
+      'body': this.state.formBody,
+      'name': this.state.formNickname,
+      'email': this.state.formEmail,
+      'product_id': this.props.id,
+    };
+    //unless were posting an answer
+    if (!this.props.question) {
+      reqUrl = `http://localhost:3000/api/fec2/hrnyc/qa/questions/${this.props.question_id}/answers`;
+      delete reqParams['product_id'];
+    }
+    axios.post(reqUrl, {
+        params: reqParams,
       })
       .then(() => {
         this.setState({
@@ -98,19 +104,25 @@ class ModalComp extends React.Component {
   }
 
   testForm(e) {
+    //set a fields object with current state values
     var fieldsObj = {
-      Question: this.state.formBody,
-      Nickname: this.state.formNickname,
-      Email: this.state.formEmail,
+      'Question': this.state.formBody,
+      'Nickname': this.state.formNickname,
+      'Email': this.state.formEmail,
     };
+    if (!this.props.question) {
+      console.log('ModalComp sees an new answer form');
+      delete fieldsObj['Question'];
+      fieldsObj['Answer'] = this.state.formBody;
+      // emptyFields.splice(0, 1, 'Answer');
+    }
+    console.log('heres my fieldsObj, it should be different based on context', fieldsObj);
+    //empty array, to capture the names of empty fields
     var emptyFields = [];
     for (var key in fieldsObj) {
       if (fieldsObj[key].length === 0) {
         emptyFields.push(key);
       }
-    }
-    if (!this.props.question) {
-      emptyFields.splice(0, 1, 'Answer');
     }
     var emptyAlertText = emptyFields.join(', ');
     if (emptyFields.length > 0) {
@@ -201,3 +213,20 @@ class ModalComp extends React.Component {
 }
 
 export default ModalComp;
+
+// //post a question
+// post('http://localhost:3000/api/fec2/hrnyc/qa/questions', {
+//         params: {
+//           'body': this.state.formBody,
+//           'name': this.state.formNickname,
+//           'email': this.state.formEmail,
+//           'product_id': this.props.id,
+//         },
+
+// //post an answer
+// post('http://localhost:3000/api/fec2/hrnyc/qa/questions/${question_id}/answers', {
+//         params: {
+//           'body': this.state.formBody,
+//           'name': this.state.formNickname,
+//           'email': this.state.formEmail
+//         },

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -4,7 +4,6 @@ import Modal from 'react-modal';
 import SearchQs from './SearchQs';
 import QAList from './QAList';
 
-// Modal.setAppElement('#app')
 Modal.setAppElement(document.getElementById('app'));
 
 class ModalComp extends React.Component {
@@ -83,18 +82,70 @@ class ModalComp extends React.Component {
   }
 
   render() {
+    console.log('prod name', this.props.prodName);
+    console.log('questionbody', this.props.question_body);
     return (
       <div>
           <Modal
            isOpen={this.props.isOpen}
            contentLabel="Minimal Modal Example"
           >
-            <button onClick={this.props.handleCloseModal}>Close Modal</button>
-            <input type="text" onChange={this.handleQuestionInput} placeholder='Your Question' />
-            <input type="text" onChange={this.handleNickmameInput} placeholder='Nickname'/>
-            <input type="text" onChange={this.handleEmailInput} placeholder='email'/>
-            <button onClick={this.submit}>Submit</button>
-
+            {this.props.question &&
+            <div>
+              <h1>
+                Ask Your Question
+              </h1>
+              <h4>
+                About the {this.props.prodName}
+              </h4>
+            </div>}
+            {!this.props.question &&
+            <div>
+              <h1>
+                Submit Your Answer
+              </h1>
+              <h4>
+                {this.props.prodName} : {this.props.question_body}
+              </h4>
+            </div>
+            }
+            <br></br>
+            <div>
+              <div>
+                Your Questions (1000 character limit)
+              </div>
+              <textarea
+                name='message'
+                style={{width: '400px', height: '200px'}}
+                type="text"
+                onChange={this.handleQuestionInput}
+              />
+            </div>
+            <br></br>
+            <div>
+              <div>
+                Your Nickname (60 character limit)
+              </div>
+              <input type="text" onChange={this.handleNickmameInput} placeholder='Example: jackson11!'/>
+              <div>
+                For privacy reasons, do not use your full name or email address
+              </div>
+            </div>
+            <br></br>
+            <div>
+              <div>
+                Your email (60 character limit)
+              </div>
+              <input type="text" onChange={this.handleEmailInput} placeholder='Example: jack@email.com'/>
+              <div>
+                For authentication reasons, you will not be emailed
+              </div>
+            </div>
+            <br></br>
+            <div>
+              <button onClick={this.props.handleCloseModal}>Close Modal</button>
+              <button onClick={this.submit}>Submit</button>
+            </div>
           </Modal>
       </div>
     );

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -4,7 +4,8 @@ import Modal from 'react-modal';
 import SearchQs from './SearchQs';
 import QAList from './QAList';
 
-Modal.setAppElement(document.getElementById('app'));
+// Modal.setAppElement(document.getElementById('app'));
+Modal.setAppElement('#app');
 
 const customStyles = {
   content: {

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -111,12 +111,10 @@ class ModalComp extends React.Component {
       'Email': this.state.formEmail,
     };
     if (!this.props.question) {
-      console.log('ModalComp sees an new answer form');
       delete fieldsObj['Question'];
       fieldsObj['Answer'] = this.state.formBody;
       // emptyFields.splice(0, 1, 'Answer');
     }
-    console.log('heres my fieldsObj, it should be different based on context', fieldsObj);
     //empty array, to capture the names of empty fields
     var emptyFields = [];
     for (var key in fieldsObj) {
@@ -151,7 +149,7 @@ class ModalComp extends React.Component {
               </div>
               <br></br>
               <div>
-                <div>* Your Question (1000 character limit)</div>
+                <div>* Your Question (Mandatory)</div>
               </div>
             </div>
           ) : (
@@ -164,7 +162,7 @@ class ModalComp extends React.Component {
               </div>
               <br></br>
               <div>
-                <div>* Your Answer (1000 character limit)</div>
+                <div>* Your Answer (Mandatory)</div>
               </div>
             </div>
           )}
@@ -179,7 +177,7 @@ class ModalComp extends React.Component {
           </div>
           <br></br>
           <div>
-            <div>* Your Nickname (60 character limit)</div>
+            <div>* What is your nickname (Mandatory)</div>
             <input
               type='text'
               onChange={this.handleNickmameInput}
@@ -192,7 +190,7 @@ class ModalComp extends React.Component {
           </div>
           <br></br>
           <div>
-            <div>* Your email (60 character limit)</div>
+            <div>* Your email (Mandatory)</div>
             <input
               type='text'
               onChange={this.handleEmailInput}
@@ -213,20 +211,3 @@ class ModalComp extends React.Component {
 }
 
 export default ModalComp;
-
-// //post a question
-// post('http://localhost:3000/api/fec2/hrnyc/qa/questions', {
-//         params: {
-//           'body': this.state.formBody,
-//           'name': this.state.formNickname,
-//           'email': this.state.formEmail,
-//           'product_id': this.props.id,
-//         },
-
-// //post an answer
-// post('http://localhost:3000/api/fec2/hrnyc/qa/questions/${question_id}/answers', {
-//         params: {
-//           'body': this.state.formBody,
-//           'name': this.state.formNickname,
-//           'email': this.state.formEmail
-//         },

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -71,7 +71,8 @@ class ModalComp extends React.Component {
       reqUrl = `http://localhost:3000/api/fec2/hrnyc/qa/questions/${this.props.question_id}/answers`;
       delete reqParams['product_id'];
     }
-    axios.post(reqUrl, {
+    axios
+      .post(reqUrl, {
         params: reqParams,
       })
       .then(() => {
@@ -106,14 +107,13 @@ class ModalComp extends React.Component {
   testForm(e) {
     //set a fields object with current state values
     var fieldsObj = {
-      'Question': this.state.formBody,
-      'Nickname': this.state.formNickname,
-      'Email': this.state.formEmail,
+      Question: this.state.formBody,
+      Nickname: this.state.formNickname,
+      Email: this.state.formEmail,
     };
     if (!this.props.question) {
       delete fieldsObj['Question'];
       fieldsObj['Answer'] = this.state.formBody;
-      // emptyFields.splice(0, 1, 'Answer');
     }
     //empty array, to capture the names of empty fields
     var emptyFields = [];

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -4,6 +4,8 @@ import Modal from 'react-modal';
 import SearchQs from './SearchQs';
 import QAList from './QAList';
 
+// Modal.setAppElement('#app')
+Modal.setAppElement(document.getElementById('app'));
 
 class ModalComp extends React.Component {
   constructor(props) {
@@ -24,9 +26,9 @@ class ModalComp extends React.Component {
 
 
   handleQuestionInput(e) {
-    var text = e.target.value;
+    console.log('question input', e.target.value);
     this.setState({
-      newQtext: text
+      newQtext: e.target.value
     });
     e.preventDefault();
   }

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -6,6 +6,17 @@ import QAList from './QAList';
 
 Modal.setAppElement(document.getElementById('app'));
 
+const customStyles = {
+  content : {
+    top                   : '50%',
+    left                  : '50%',
+    right                 : 'auto',
+    bottom                : 'auto',
+    marginRight           : '-50%',
+    transform             : 'translate(-50%, -50%)'
+  }
+};
+
 class ModalComp extends React.Component {
   constructor(props) {
     super(props);
@@ -87,6 +98,7 @@ class ModalComp extends React.Component {
     return (
       <div>
           <Modal
+           style={customStyles}
            isOpen={this.props.isOpen}
            contentLabel="Minimal Modal Example"
           >

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -4,7 +4,6 @@ import Modal from 'react-modal';
 import SearchQs from './SearchQs';
 import QAList from './QAList';
 
-// Modal.setAppElement(document.getElementById('app'));
 Modal.setAppElement('#app');
 
 const customStyles = {

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -7,164 +7,193 @@ import QAList from './QAList';
 Modal.setAppElement(document.getElementById('app'));
 
 const customStyles = {
-  content : {
-    top                   : '50%',
-    left                  : '50%',
-    right                 : 'auto',
-    bottom                : 'auto',
-    marginRight           : '-50%',
-    transform             : 'translate(-50%, -50%)'
-  }
+  content: {
+    top: '50%',
+    left: '50%',
+    right: 'auto',
+    bottom: 'auto',
+    marginRight: '-50%',
+    transform: 'translate(-50%, -50%)',
+  },
 };
 
 class ModalComp extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      newQnickname: '',
-      newQtext: '',
-      newQemail: '',
+      formBody: '',
+      formNickname: '',
+      formEmail: '',
       newQphotos: [],
-      showModal: false
+      showModal: false,
     };
 
     this.handleNickmameInput = this.handleNickmameInput.bind(this);
     this.handleQuestionInput = this.handleQuestionInput.bind(this);
     this.handleEmailInput = this.handleEmailInput.bind(this);
+    this.testForm = this.testForm.bind(this);
     this.submit = this.submit.bind(this);
+    this.validateEmail = this.validateEmail.bind(this);
   }
 
-
   handleQuestionInput(e) {
-    console.log('question input', e.target.value);
     this.setState({
-      newQtext: e.target.value
+      formBody: e.target.value,
     });
     e.preventDefault();
   }
 
   handleNickmameInput(e) {
     this.setState({
-      newQnickname: e.target.value
+      formNickname: e.target.value,
     });
     e.preventDefault();
   }
 
   handleEmailInput(e) {
     this.setState({
-      newQemail: e.target.value
+      formEmail: e.target.value,
     });
     e.preventDefault();
-
   }
 
-  submit(e) {
-    axios.post('http://localhost:3000/api/fec2/hrnyc/qa/questions', {
-      params: {
-        'body': this.state.newQtext,
-        'name': this.state.newQnickname,
-        'email': this.state.newQemail,
-        'product_id': this.props.id
-      }
-    })
-      .then(()=>{
+  submit() {
+    axios
+    //this is built out to POST a new question, need to build POST answer logic
+      .post('http://localhost:3000/api/fec2/hrnyc/qa/questions', {
+        params: {
+          'body': this.state.formBody,
+          'name': this.state.formNickname,
+          'email': this.state.formEmail,
+          'product_id': this.props.id,
+        },
+      })
+      .then(() => {
         this.setState({
           showModal: false,
-          newQnickname: '',
-          newQtext: '',
-          newQemail: ''
+          formNickname: '',
+          formBody: '',
+          formEmail: '',
         });
-        // this.handleCloseModal();
-
       })
       .catch((err) => {
         console.error(err);
         this.setState({
           showModal: false,
-          newQnickname: '',
-          newQtext: '',
-          newQemail: ''
+          formNickname: '',
+          formBody: '',
+          formEmail: '',
         });
-        // this.handleCloseModal();
       });
-      this.props.handleCloseModal();
-      e.preventDefault();
+    this.props.handleCloseModal();
+  }
 
+  validateEmail(inputText) {
+    var mailformat = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+    if (inputText.match(mailformat)) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  testForm(e) {
+    console.log('test form');
+    var fieldsObj = {
+      'form body': this.state.formBody,
+      Nickname: this.state.formNickname,
+      Email: this.state.formEmail,
+    };
+    var emptyFields = [];
+    for (var key in fieldsObj) {
+      if (fieldsObj[key].length === 0) {
+        emptyFields.push(key);
+      }
+    }
+    var emptyAlertText = emptyFields.join(', ');
+    if (emptyFields.length > 0) {
+      console.log('empty alert text', emptyAlertText);
+      alert('You must enter the following: ' + emptyAlertText);
+    } else if (!this.validateEmail(this.state.formEmail)) {
+      alert('Please enter a valid email address');
+    } else {
+      this.submit();
+    }
+    e.preventDefault();
   }
 
   render() {
-    console.log('prod name', this.props.prodName);
-    console.log('questionbody', this.props.question_body);
     return (
       <div>
-          <Modal
-           style={customStyles}
-           isOpen={this.props.isOpen}
-           contentLabel="Minimal Modal Example"
-          >
-            {this.props.question ?
+        <Modal
+          style={customStyles}
+          isOpen={this.props.isOpen}
+          contentLabel='Minimal Modal Example'
+        >
+          {this.props.question ? (
             <div>
               <div>
-                <h1>
-                  Ask Your Question
-                </h1>
-                <h4>
-                  About the {this.props.prodName}
-                </h4>
+                <h1>Ask Your Question</h1>
+                <h4>About the {this.props.prodName}</h4>
+              </div>
+              <br></br>
+              <div>
+                <div>* Your Question (1000 character limit)</div>
               </div>
             </div>
-            :
+          ) : (
             <div>
               <div>
-                <h1>
-                  Submit Your Answer
-                </h1>
+                <h1>Submit Your Answer</h1>
                 <h4>
                   {this.props.prodName} : {this.props.question_body}
                 </h4>
               </div>
               <br></br>
               <div>
-                <div>
-                  Your Questions (1000 character limit)
-                </div>
+                <div>* Your Answer (1000 character limit)</div>
               </div>
             </div>
-            }
+          )}
+          <div>
+            <textarea
+              name='message'
+              style={{ width: '400px', height: '200px' }}
+              type='text'
+              onChange={this.handleQuestionInput}
+              maxLength='1000'
+            />
+          </div>
+          <br></br>
+          <div>
+            <div>* Your Nickname (60 character limit)</div>
+            <input
+              type='text'
+              onChange={this.handleNickmameInput}
+              placeholder='Example: jackson11!'
+              maxLength='60'
+            />
             <div>
-              <textarea
-                name='message'
-                style={{width: '400px', height: '200px'}}
-                type="text"
-                onChange={this.handleQuestionInput}
-              />
+              For privacy reasons, do not use your full name or email address
             </div>
-            <br></br>
-            <div>
-              <div>
-                Your Nickname (60 character limit)
-              </div>
-              <input type="text" onChange={this.handleNickmameInput} placeholder='Example: jackson11!'/>
-              <div>
-                For privacy reasons, do not use your full name or email address
-              </div>
-            </div>
-            <br></br>
-            <div>
-              <div>
-                Your email (60 character limit)
-              </div>
-              <input type="text" onChange={this.handleEmailInput} placeholder='Example: jack@email.com'/>
-              <div>
-                For authentication reasons, you will not be emailed
-              </div>
-            </div>
-            <br></br>
-            <div>
-              <button onClick={this.props.handleCloseModal}>Close Modal</button>
-              <button onClick={this.submit}>Submit</button>
-            </div>
-          </Modal>
+          </div>
+          <br></br>
+          <div>
+            <div>* Your email (60 character limit)</div>
+            <input
+              type='text'
+              onChange={this.handleEmailInput}
+              placeholder='Example: jack@email.com'
+              maxLength='60'
+            />
+            <div>For authentication reasons, you will not be emailed</div>
+          </div>
+          <br></br>
+          <div>
+            <button onClick={this.props.handleCloseModal}>Close Modal</button>
+            <button onClick={this.testForm}>Submit</button>
+          </div>
+        </Modal>
       </div>
     );
   }

--- a/client/components/QnAs/ModalComp.jsx
+++ b/client/components/QnAs/ModalComp.jsx
@@ -90,30 +90,36 @@ class ModalComp extends React.Component {
            isOpen={this.props.isOpen}
            contentLabel="Minimal Modal Example"
           >
-            {this.props.question &&
-            <div>
-              <h1>
-                Ask Your Question
-              </h1>
-              <h4>
-                About the {this.props.prodName}
-              </h4>
-            </div>}
-            {!this.props.question &&
-            <div>
-              <h1>
-                Submit Your Answer
-              </h1>
-              <h4>
-                {this.props.prodName} : {this.props.question_body}
-              </h4>
-            </div>
-            }
-            <br></br>
+            {this.props.question ?
             <div>
               <div>
-                Your Questions (1000 character limit)
+                <h1>
+                  Ask Your Question
+                </h1>
+                <h4>
+                  About the {this.props.prodName}
+                </h4>
               </div>
+            </div>
+            :
+            <div>
+              <div>
+                <h1>
+                  Submit Your Answer
+                </h1>
+                <h4>
+                  {this.props.prodName} : {this.props.question_body}
+                </h4>
+              </div>
+              <br></br>
+              <div>
+                <div>
+                  Your Questions (1000 character limit)
+                </div>
+              </div>
+            </div>
+            }
+            <div>
               <textarea
                 name='message'
                 style={{width: '400px', height: '200px'}}

--- a/client/components/QnAs/QAItem.jsx
+++ b/client/components/QnAs/QAItem.jsx
@@ -1,3 +1,0 @@
-import React from 'react';
-
-export default QAItem;

--- a/client/components/QnAs/QAList.jsx
+++ b/client/components/QnAs/QAList.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import axios from 'axios';
 import Question from './Question';
 
-
 class QAList extends React.Component {
   constructor(props) {
     super(props);
@@ -14,19 +13,18 @@ class QAList extends React.Component {
 
   componentDidMount() {
     //why can't i use a template literal here?
-    axios.get('http://localhost:3000/api/fec2/hrnyc/qa/questions?product_id=11001')
+    axios
+      .get('http://localhost:3000/api/fec2/hrnyc/qa/questions?product_id=11001')
       .then((productInfo) => {
-        // console.log('product info', productInfo.data.results);
         this.setState({
-          questionData: productInfo.data.results
+          questionData: productInfo.data.results,
         });
       })
       .catch((err) => console.error(err));
   }
 
-
   render() {
-    var QAItemArr = this.state.questionData.map((question)=>{
+    var QAItemArr = this.state.questionData.map((question) => {
       var answersArr = Object.values(question.answers);
       if (answersArr.length > 0) {
         var questionAnswerText = answersArr.map((answer) => {
@@ -34,8 +32,6 @@ class QAList extends React.Component {
         });
       }
       var allText = question.question_body + questionAnswerText;
-      // console.log('all text', allText);
-
       if (allText.indexOf(this.props.searchTerm) > -1) {
         return (
           <div key={question.question_id}>
@@ -48,14 +44,11 @@ class QAList extends React.Component {
           </div>
         );
       }
-
     });
 
     return (
       <div>
-        <div>
-          {QAItemArr}
-        </div>
+        <div>{QAItemArr}</div>
       </div>
     );
   }

--- a/client/components/QnAs/QAList.jsx
+++ b/client/components/QnAs/QAList.jsx
@@ -14,7 +14,7 @@ class QAList extends React.Component {
   componentDidMount() {
     //why can't i use a template literal here?
     axios
-      .get('http://localhost:3000/api/fec2/hrnyc/qa/questions?product_id=11001')
+      .get('/api/fec2/hrnyc/qa/questions?product_id=11001')
       .then((productInfo) => {
         this.setState({
           questionData: productInfo.data.results,
@@ -24,13 +24,19 @@ class QAList extends React.Component {
   }
 
   render() {
+    //facilitates search - this line goes through the question
     var QAItemArr = this.state.questionData.map((question) => {
+      //answersArr is an array containing all answer text for this question
       var answersArr = Object.values(question.answers);
+      //if there are answers for this question
       if (answersArr.length > 0) {
+        //map over all answers, put them in QAT
         var questionAnswerText = answersArr.map((answer) => {
           return answer.body;
         });
       }
+
+      //put all question text and answer text in one string
       var allText = question.question_body + questionAnswerText;
       if (allText.indexOf(this.props.searchTerm) > -1) {
         return (

--- a/client/components/QnAs/QAList.jsx
+++ b/client/components/QnAs/QAList.jsx
@@ -42,6 +42,7 @@ class QAList extends React.Component {
             <Question
               id={this.props.id}
               question={question}
+              prodName={this.props.prodName}
               answers={Object.values(question.answers)}
             />
           </div>

--- a/client/components/QnAs/QnAs.jsx
+++ b/client/components/QnAs/QnAs.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import Modal from 'react-modal';
 import SearchQs from './SearchQs';
 import QAList from './QAList';
+import ModalComp from './ModalComp';
 
 class QnAs extends React.Component {
   constructor(props) {
@@ -24,10 +25,10 @@ class QnAs extends React.Component {
     this.updateSearchTerm = this.updateSearchTerm.bind(this);
     this.handleOpenModal = this.handleOpenModal.bind(this);
     this.handleCloseModal = this.handleCloseModal.bind(this);
-    this.handleNickmameInput = this.handleNickmameInput.bind(this);
-    this.handleQuestionInput = this.handleQuestionInput.bind(this);
-    this.handleEmailInput = this.handleEmailInput.bind(this);
-    this.submit = this.submit.bind(this);
+    // this.handleNickmameInput = this.handleNickmameInput.bind(this);
+    // this.handleQuestionInput = this.handleQuestionInput.bind(this);
+    // this.handleEmailInput = this.handleEmailInput.bind(this);
+    // this.submit = this.submit.bind(this);
 
   }
 
@@ -39,73 +40,71 @@ class QnAs extends React.Component {
     this.setState({ showModal: false });
   }
 
-  handleQuestionInput(e) {
-    // console.log('value', e.target.value);
-    var text = e.target.value;
-    this.setState({
-      newQtext: text
-    });
-    e.preventDefault();
-  }
+  // handleQuestionInput(e) {
+  //   // console.log('value', e.target.value);
+  //   var text = e.target.value;
+  //   this.setState({
+  //     newQtext: text
+  //   });
+  //   e.preventDefault();
+  // }
 
-  handleNickmameInput(e) {
-    // console.log('value', e.target.value);
-    e.preventDefault();
-    this.setState({
-      newQnickname: e.target.value
-    });
-  }
+  // handleNickmameInput(e) {
+  //   // console.log('value', e.target.value);
+  //   e.preventDefault();
+  //   this.setState({
+  //     newQnickname: e.target.value
+  //   });
+  // }
 
-  handleEmailInput(e) {
-    console.log('value', e.target.value);
+  // handleEmailInput(e) {
+  //   console.log('value', e.target.value);
 
-    this.setState({
-      newQemail: e.target.value
-    });
-    // e.preventDefault();
-  }
+  //   this.setState({
+  //     newQemail: e.target.value
+  //   });
+  //   // e.preventDefault();
+  // }
 
-  submit(e) {
-    // console.log('submit!', this.state);
-    // e.preventDefault();
+  // submit(e) {
+  //   // console.log('submit!', this.state);
+  //   // e.preventDefault();
 
-    axios.post('http://localhost:3000/api/fec2/hrnyc/qa/questions', {
-      params: {
-        'body': this.state.newQtext,
-        'name': this.state.newQnickname,
-        'email': this.state.newQemail,
-        'product_id': this.props.product.id
-      }
-    })
-      .then((productInfo) => {
-        console.log('product info', productInfo.data.results);
-        this.setState({
-          questionData: productInfo.data.results
-        });
-      })
-      .then(()=>{
-        this.setState({
-          showModal: false,
-          newQnickname: '',
-          newQtext: '',
-          newQemail: ''
-        });
-      })
-      .catch((err) => {
-        console.error(err);
-        this.setState({
-          showModal: false,
-          newQnickname: '',
-          newQtext: '',
-          newQemail: ''
-        });
-      });
-      e.preventDefault();
+  //   axios.post('http://localhost:3000/api/fec2/hrnyc/qa/questions', {
+  //     params: {
+  //       'body': this.state.newQtext,
+  //       'name': this.state.newQnickname,
+  //       'email': this.state.newQemail,
+  //       'product_id': this.props.product.id
+  //     }
+  //   })
+  //     .then((productInfo) => {
+  //       console.log('product info', productInfo.data.results);
+  //       this.setState({
+  //         questionData: productInfo.data.results
+  //       });
+  //     })
+  //     .then(()=>{
+  //       this.setState({
+  //         showModal: false,
+  //         newQnickname: '',
+  //         newQtext: '',
+  //         newQemail: ''
+  //       });
+  //     })
+  //     .catch((err) => {
+  //       console.error(err);
+  //       this.setState({
+  //         showModal: false,
+  //         newQnickname: '',
+  //         newQtext: '',
+  //         newQemail: ''
+  //       });
+  //     });
+  //     e.preventDefault();
 
-  }
-  componentDidMount() {
+  // }
 
-  }
 
   updateSearchTerm(e) {
 
@@ -129,7 +128,12 @@ class QnAs extends React.Component {
           id={this.props.product.id}
           searchTerm={this.state.searchTerm}
           />
-          <Modal
+          <ModalComp
+            isOpen={this.state.showModal}
+            handleCloseModal={this.handleCloseModal}
+            id={this.props.product.id}
+          />
+          {/* <Modal
            isOpen={this.state.showModal}
            contentLabel="Minimal Modal Example"
           >
@@ -139,7 +143,7 @@ class QnAs extends React.Component {
             <input type="text" onChange={this.handleEmailInput} placeholder='email'/>
             <button onClick={this.submit}>Submit</button>
 
-          </Modal>
+          </Modal> */}
         <button>
           MORE ANSWERED QUESTIONS
         </button>

--- a/client/components/QnAs/QnAs.jsx
+++ b/client/components/QnAs/QnAs.jsx
@@ -10,15 +10,7 @@ class QnAs extends React.Component {
     super(props);
     this.state = {
       searchTerm: '',
-      questionsIDs: [],
-      questions: [],
-      answersIDs: [],
-      answers: [],
       visibleQsQuant: 2,
-      newQnickname: '',
-      newQtext: '',
-      newQemail: '',
-      newQphotos: [],
       showModal: false
 
     };
@@ -34,72 +26,6 @@ class QnAs extends React.Component {
   handleCloseModal () {
     this.setState({ showModal: false });
   }
-
-  // handleQuestionInput(e) {
-  //   // console.log('value', e.target.value);
-  //   var text = e.target.value;
-  //   this.setState({
-  //     newQtext: text
-  //   });
-  //   e.preventDefault();
-  // }
-
-  // handleNickmameInput(e) {
-  //   // console.log('value', e.target.value);
-  //   e.preventDefault();
-  //   this.setState({
-  //     newQnickname: e.target.value
-  //   });
-  // }
-
-  // handleEmailInput(e) {
-  //   console.log('value', e.target.value);
-
-  //   this.setState({
-  //     newQemail: e.target.value
-  //   });
-  //   // e.preventDefault();
-  // }
-
-  // submit(e) {
-  //   // console.log('submit!', this.state);
-  //   // e.preventDefault();
-
-  //   axios.post('http://localhost:3000/api/fec2/hrnyc/qa/questions', {
-  //     params: {
-  //       'body': this.state.newQtext,
-  //       'name': this.state.newQnickname,
-  //       'email': this.state.newQemail,
-  //       'product_id': this.props.product.id
-  //     }
-  //   })
-  //     .then((productInfo) => {
-  //       console.log('product info', productInfo.data.results);
-  //       this.setState({
-  //         questionData: productInfo.data.results
-  //       });
-  //     })
-  //     .then(()=>{
-  //       this.setState({
-  //         showModal: false,
-  //         newQnickname: '',
-  //         newQtext: '',
-  //         newQemail: ''
-  //       });
-  //     })
-  //     .catch((err) => {
-  //       console.error(err);
-  //       this.setState({
-  //         showModal: false,
-  //         newQnickname: '',
-  //         newQtext: '',
-  //         newQemail: ''
-  //       });
-  //     });
-  //     e.preventDefault();
-
-  // }
-
 
   updateSearchTerm(e) {
 

--- a/client/components/QnAs/QnAs.jsx
+++ b/client/components/QnAs/QnAs.jsx
@@ -25,11 +25,6 @@ class QnAs extends React.Component {
     this.updateSearchTerm = this.updateSearchTerm.bind(this);
     this.handleOpenModal = this.handleOpenModal.bind(this);
     this.handleCloseModal = this.handleCloseModal.bind(this);
-    // this.handleNickmameInput = this.handleNickmameInput.bind(this);
-    // this.handleQuestionInput = this.handleQuestionInput.bind(this);
-    // this.handleEmailInput = this.handleEmailInput.bind(this);
-    // this.submit = this.submit.bind(this);
-
   }
 
   handleOpenModal () {
@@ -120,6 +115,7 @@ class QnAs extends React.Component {
   }
 
   render() {
+    // console.log('product data', this.props.product);
     return (
       <div>
         <h1>Quesions and Answers</h1>
@@ -127,23 +123,15 @@ class QnAs extends React.Component {
         <QAList
           id={this.props.product.id}
           searchTerm={this.state.searchTerm}
+          prodName={this.props.product.name}
           />
           <ModalComp
             isOpen={this.state.showModal}
             handleCloseModal={this.handleCloseModal}
             id={this.props.product.id}
+            question={true}
+            prodName={this.props.product.name}
           />
-          {/* <Modal
-           isOpen={this.state.showModal}
-           contentLabel="Minimal Modal Example"
-          >
-            <button onClick={this.handleCloseModal}>Close Modal</button>
-            <input type="text" onChange={this.handleQuestionInput} placeholder='Your Question' />
-            <input type="text" onChange={this.handleNickmameInput} placeholder='Nickname'/>
-            <input type="text" onChange={this.handleEmailInput} placeholder='email'/>
-            <button onClick={this.submit}>Submit</button>
-
-          </Modal> */}
         <button>
           MORE ANSWERED QUESTIONS
         </button>

--- a/client/components/QnAs/Question.jsx
+++ b/client/components/QnAs/Question.jsx
@@ -5,11 +5,10 @@ class Question extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      question: this.props.question,
-      answers: this.props.answers,
       visible: [],
+      allAnswers: [],
       loadMoreLess: 'LOAD MORE ANSWERS',
-      less: true,
+      less: true
     };
     this.toggleMoreFewer = this.toggleMoreFewer.bind(this);
   }
@@ -21,6 +20,7 @@ class Question extends React.Component {
       });
       this.setState({
         visible: this.props.answers.slice(0, 2),
+        allAnswers: this.props.answers
       });
     }
   }
@@ -33,13 +33,13 @@ class Question extends React.Component {
   toggleMoreFewer() {
     if (this.state.less) {
       this.setState({
-        visible: this.state.answers,
+        visible: this.props.answers,
         loadMoreLess: 'SHOW FEWER',
         less: false,
       });
     } else {
       this.setState({
-        visible: this.state.answers.slice(0, 2),
+        visible: this.props.answers.slice(0, 2),
         loadMoreLess: 'LOAD MORE ANSWERS',
         less: true,
       });
@@ -71,7 +71,7 @@ class Question extends React.Component {
         );
       }
     });
-    // var messagesShownController =
+
     return (
       <div>
         <h4>
@@ -80,7 +80,7 @@ class Question extends React.Component {
         {answersArr}
         <br></br>
         <div>
-          {this.state.answers.length > 2 ? (
+          {this.props.answers.length > 2 ? (
             <a onClick={this.toggleMoreFewer}>{this.state.loadMoreLess}</a>
           ) : null}
         </div>

--- a/client/components/QnAs/Question.jsx
+++ b/client/components/QnAs/Question.jsx
@@ -16,7 +16,7 @@ class Question extends React.Component {
 
   componentDidMount() {
     if (this.props.answers.length > 0) {
-      var sortedAnswers = this.props.answers.sort(function(a, b) {
+      var sortedAnswers = this.props.answers.sort(function (a, b) {
         return b.helpfulness - a.helpfulness;
       });
       this.setState({
@@ -54,8 +54,7 @@ class Question extends React.Component {
         return (
           <div key={answer.id}>
             <h4>
-              A
-              <div>{answer.body}</div>
+              A<div>{answer.body}</div>
             </h4>
             <div>
               by {answer.answerer_name}, {answer.date.substring(0, 10)}
@@ -76,8 +75,8 @@ class Question extends React.Component {
     return (
       <div>
         <h4>
-          Q
-          <div>{this.props.question.question_body}</div></h4>
+          Q<div>{this.props.question.question_body}</div>
+        </h4>
         {answersArr}
         <br></br>
         <div>
@@ -88,12 +87,12 @@ class Question extends React.Component {
         <div>
           {/* //controls the answer instances of helpfulReport*/}
           <HelpfulReport
-              id={this.props.id}
-              helpVotes={this.props.question.question_helpfulness}
-              answerUsage={false}
-              question_body={this.props.question.question_body}
-              question_id={this.props.question.question_id}
-              prodName={this.props.prodName}
+            id={this.props.id}
+            helpVotes={this.props.question.question_helpfulness}
+            answerUsage={false}
+            question_body={this.props.question.question_body}
+            question_id={this.props.question.question_id}
+            prodName={this.props.prodName}
           />
         </div>
       </div>

--- a/client/components/QnAs/Question.jsx
+++ b/client/components/QnAs/Question.jsx
@@ -92,6 +92,7 @@ class Question extends React.Component {
               helpVotes={this.props.question.question_helpfulness}
               answerUsage={false}
               question_body={this.props.question.question_body}
+              question_id={this.props.question.question_id}
               prodName={this.props.prodName}
           />
         </div>

--- a/client/components/QnAs/Question.jsx
+++ b/client/components/QnAs/Question.jsx
@@ -49,7 +49,7 @@ class Question extends React.Component {
   render() {
     var answersArr = this.state.visible.map((answer) => {
       if (answer.length === 0) {
-        return <span/>;
+        return null;
       } else {
         return (
           <div key={answer.id}>

--- a/client/components/QnAs/Question.jsx
+++ b/client/components/QnAs/Question.jsx
@@ -60,10 +60,13 @@ class Question extends React.Component {
             <div>
               by {answer.answerer_name}, {answer.date.substring(0, 10)}
             </div>
+            {/* //controls the question instances of helpfulReport*/}
             <HelpfulReport
               id={this.props.id}
               helpVotes={answer.helpfulness}
               answerUsage={true}
+              question_body={this.props.question_body}
+              prodName={this.props.prodName}
             />
           </div>
         );
@@ -83,10 +86,13 @@ class Question extends React.Component {
           ) : null}
         </div>
         <div>
+          {/* //controls the answer instances of helpfulReport*/}
           <HelpfulReport
               id={this.props.id}
               helpVotes={this.props.question.question_helpfulness}
               answerUsage={false}
+              question_body={this.props.question.question_body}
+              prodName={this.props.prodName}
           />
         </div>
       </div>

--- a/client/components/QnAs/Question.jsx
+++ b/client/components/QnAs/Question.jsx
@@ -63,6 +63,7 @@ class Question extends React.Component {
             <HelpfulReport
               id={this.props.id}
               helpVotes={answer.helpfulness}
+              answerUsage={true}
             />
           </div>
         );
@@ -80,6 +81,13 @@ class Question extends React.Component {
           {this.state.answers.length > 2 ? (
             <a onClick={this.toggleMoreFewer}>{this.state.loadMoreLess}</a>
           ) : null}
+        </div>
+        <div>
+          <HelpfulReport
+              id={this.props.id}
+              helpVotes={this.props.question.question_helpfulness}
+              answerUsage={false}
+          />
         </div>
       </div>
     );

--- a/client/components/QnAs/SearchQs.jsx
+++ b/client/components/QnAs/SearchQs.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-var SearchQs = function({ updateSearchTerm }) {
+var SearchQs = function ({ updateSearchTerm }) {
   return (
     <div>
       <input
         type='text'
         onChange={updateSearchTerm}
-        style={{ width:"80%" }}
+        style={{ width: '80%' }}
         placeholder='Have a question? Search for answers…'
       />
     </div>


### PR DESCRIPTION
This feature branch was related to the 'modal form', the component that pops up when the user clicks EITHER 'ADD A QUESTION' (found at the bottom of my widget) OR 'Add Answer' (found underneath each question/its answers). 

I reused the same component (as there is a whole lot of common features/functionality), but it is smart enough to render out differently, and make different kinds of POST reqs (see note below on these requests) to the server based on which button you clicked to pull it up.

The title and subtitle for the modal response to Question/Answer.  

The fields have maximum character limits. The page will also throw an 'alert' if EITHER a field is empty OR the entered email address doesn't have the right syntax (this might not be a perfect test, but it works pretty well upon minimal user testing). 

There's obviously A LOT of code here, and I didn't really include any comments. Let me know if I should go back there and put them in, and/or I can talk through it if need be. 

Note: I believe this part of my widget meets all of the requirements with two exceptions
1. All my POST requests get status 422 responses, not sure what the issue might be, but it can't be that difficult to fix once we figure it out
2. I have not implemented any 'upload photos' functionality. The reqs indicate this can be a future enhancement, so I opted to save this for later.