### PR TITLE
51 toggle more fewer qs

### DIFF
--- a/client/components/QnAs/QAList.jsx
+++ b/client/components/QnAs/QAList.jsx
@@ -20,6 +20,9 @@ class QAList extends React.Component {
           questionData: productInfo.data.results,
         });
       })
+      .then(()=>{
+        this.props.getQuestionQuantity(this.state.questionData.length);
+      })
       .catch((err) => console.error(err));
   }
 
@@ -50,7 +53,7 @@ class QAList extends React.Component {
           </div>
         );
       }
-    });
+    }).slice(0, this.props.visibleQsQuant);
 
     return (
       <div>

--- a/client/components/QnAs/QnAs.jsx
+++ b/client/components/QnAs/QnAs.jsx
@@ -11,8 +11,9 @@ class QnAs extends React.Component {
     this.state = {
       searchTerm: '',
       visibleQsQuant: 2,
-      allQsQuanity: 2,
+      allQsQuanity: null,
       showModal: false,
+      showMoreQsBtn: true
       // visibleQuestions: [],
       // allQuestions: []
 
@@ -21,6 +22,7 @@ class QnAs extends React.Component {
     this.handleOpenModal = this.handleOpenModal.bind(this);
     this.handleCloseModal = this.handleCloseModal.bind(this);
     this.getQuestionQuantity = this.getQuestionQuantity.bind(this);
+    this.addQuestions = this.addQuestions.bind(this);
   }
 
   handleOpenModal () {
@@ -36,7 +38,16 @@ class QnAs extends React.Component {
       allQsQuanity: value
     });
   }
-
+  addQuestions () {
+    // if (this.state.visibleQsQuant >= this.state.allQsQuanity) {
+    //   this.setState({
+    //     showMoreQsBtn: false
+    //   })
+    // }
+    this.setState({
+      visibleQsQuant: this.state.visibleQsQuant + 2
+    });
+  }
   updateSearchTerm(e) {
 
     if (e.target.value.length > 2) {
@@ -72,12 +83,17 @@ class QnAs extends React.Component {
             question={true}
             prodName={this.props.product.name}
           />
-        <button>
+        {(this.state.allQsQuanity > 2) ?
+        <button onClick={this.addQuestions}>
           MORE ANSWERED QUESTIONS
         </button>
+        : <div/>
+        }
+        {this.state.visibleQsQuant < this.state.allQsQuanity
+        &&
         <button onClick={this.handleOpenModal}>
           ADD A QUESTION +
-        </button>
+        </button>}
       </div>
     );
   }

--- a/client/components/QnAs/QnAs.jsx
+++ b/client/components/QnAs/QnAs.jsx
@@ -14,8 +14,6 @@ class QnAs extends React.Component {
       allQsQuanity: null,
       showModal: false,
       showMoreQsBtn: true
-      // visibleQuestions: [],
-      // allQuestions: []
 
     };
     this.updateSearchTerm = this.updateSearchTerm.bind(this);
@@ -39,11 +37,6 @@ class QnAs extends React.Component {
     });
   }
   addQuestions () {
-    // if (this.state.visibleQsQuant >= this.state.allQsQuanity) {
-    //   this.setState({
-    //     showMoreQsBtn: false
-    //   })
-    // }
     this.setState({
       visibleQsQuant: this.state.visibleQsQuant + 2
     });
@@ -83,17 +76,15 @@ class QnAs extends React.Component {
             question={true}
             prodName={this.props.product.name}
           />
-        {(this.state.allQsQuanity > 2) ?
+        {(this.state.allQsQuanity > 2 && this.state.visibleQsQuant < this.state.allQsQuanity) ?
         <button onClick={this.addQuestions}>
           MORE ANSWERED QUESTIONS
         </button>
         : <div/>
         }
-        {this.state.visibleQsQuant < this.state.allQsQuanity
-        &&
         <button onClick={this.handleOpenModal}>
           ADD A QUESTION +
-        </button>}
+        </button>
       </div>
     );
   }

--- a/client/components/QnAs/QnAs.jsx
+++ b/client/components/QnAs/QnAs.jsx
@@ -11,12 +11,16 @@ class QnAs extends React.Component {
     this.state = {
       searchTerm: '',
       visibleQsQuant: 2,
-      showModal: false
+      allQsQuanity: 2,
+      showModal: false,
+      // visibleQuestions: [],
+      // allQuestions: []
 
     };
     this.updateSearchTerm = this.updateSearchTerm.bind(this);
     this.handleOpenModal = this.handleOpenModal.bind(this);
     this.handleCloseModal = this.handleCloseModal.bind(this);
+    this.getQuestionQuantity = this.getQuestionQuantity.bind(this);
   }
 
   handleOpenModal () {
@@ -27,15 +31,23 @@ class QnAs extends React.Component {
     this.setState({ showModal: false });
   }
 
+  getQuestionQuantity(value) {
+    this.setState({
+      allQsQuanity: value
+    });
+  }
+
   updateSearchTerm(e) {
 
     if (e.target.value.length > 2) {
       this.setState({
-        searchTerm: e.target.value
+        searchTerm: e.target.value,
+        visibleQsQuant: this.state.allQsQuanity
       });
     } else {
       this.setState({
-        searchTerm: ''
+        searchTerm: '',
+        visibleQsQuant: 2
       });
     }
   }
@@ -50,6 +62,8 @@ class QnAs extends React.Component {
           id={this.props.product.id}
           searchTerm={this.state.searchTerm}
           prodName={this.props.product.name}
+          visibleQsQuant={this.state.visibleQsQuant}
+          getQuestionQuantity={this.getQuestionQuantity}
           />
           <ModalComp
             isOpen={this.state.showModal}


### PR DESCRIPTION
This feature covers the input the user has to see more questions. 

By default, just two questions should be rendered to the page. At the bottom of the list of Qs is a button that can show more questions. Each time it is clicked, two more show up on the page. Once all the questions are rendered, the button disappears. 
