### PR TITLE
135 add advanced styling and functionality to overview widget

### DIFF
--- a/TESTING_README.md
+++ b/TESTING_README.md
@@ -3,7 +3,7 @@
 Run all jest test: `npm test`
 
 ### Test File Naming
-Test files should be named accorind to the following convention: <filebeingtested>.test.js.
+Test files should be named according to the following convention: <filebeingtested>.test.js.
 ex. If you are testing App.jsx the test file should be called: App.test.js.
 
 Test files should be in the directory as the file they are testing or alternatively they can be kept in a directory called '__test__'.

--- a/client/components/Overview.jsx
+++ b/client/components/Overview.jsx
@@ -5,8 +5,6 @@ import StyleSelector from './overviewWidget/StyleSelector.jsx';
 import AddToCart from './overviewWidget/AddToCart.jsx';
 import ProductOverview from './overviewWidget/ProductOverview.jsx';
 import axios from 'axios';
-import './overviewWidget/styles/OverviewStyles.scss';
-
 
 class Overview extends React.Component {
   constructor(props) {
@@ -14,7 +12,7 @@ class Overview extends React.Component {
 
     this.state = {
       styles: [],
-      selectedStyle: null
+      selectedStyle: null,
     };
 
     this.clickedStyleHandler = this.clickedStyleHandler.bind(this);
@@ -22,10 +20,11 @@ class Overview extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.product !== prevProps.product) {
-      axios.get(`/api/fec2/hrnyc/products/${this.props.product.id}/styles`)
-        .then(({data}) => {
+      axios
+        .get(`/api/fec2/hrnyc/products/${this.props.product.id}/styles`)
+        .then(({ data }) => {
           this.setState({
-            styles: data.results
+            styles: data.results,
           });
         })
         .catch((err) => {
@@ -36,11 +35,11 @@ class Overview extends React.Component {
 
   clickedStyleHandler(e) {
     this.setState({
-      selectedStyle: e.target.id
+      selectedStyle: e.target.id,
     });
   }
 
-  render () {
+  render() {
     return (
       <div className="main-grid">
         <ImageGallery
@@ -65,9 +64,7 @@ class Overview extends React.Component {
             selectedStyle={this.state.selectedStyle}
           />
         </div>
-        <ProductOverview
-          product={this.props.product}
-        />
+        <ProductOverview product={this.props.product} />
       </div>
     );
   }

--- a/client/components/ReviewsWidget.jsx
+++ b/client/components/ReviewsWidget.jsx
@@ -210,7 +210,7 @@ export class ReviewsWidget extends Component {
   render() {
     return (
       <div className="reviews-widget">
-        <h3>{'Ratings & Reviews'}</h3>
+        <a name="anchor"><h3>{'Ratings & Reviews'}</h3></a>
         <div className="reviews-container">
           <RatingBreakdown
             reviewMetaData={this.props.reviewMetaData}

--- a/client/components/overviewWidget/AddToCart.jsx
+++ b/client/components/overviewWidget/AddToCart.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import axios from 'axios';
-import './styles/OverviewStyles.scss';
-
 
 class AddToCart extends React.Component {
   constructor(props) {

--- a/client/components/overviewWidget/ImageGallery.jsx
+++ b/client/components/overviewWidget/ImageGallery.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Thumbnails from './Thumbnails.jsx';
 import axios from 'axios';
-import './styles/OverviewStyles.scss';
 
 class ImageGallery extends React.Component {
   constructor(props) {

--- a/client/components/overviewWidget/ProductFeatures.jsx
+++ b/client/components/overviewWidget/ProductFeatures.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// import axios from 'axios';
 
 class ProductFeatures extends React.Component {
   constructor(props) {

--- a/client/components/overviewWidget/ProductInformation.jsx
+++ b/client/components/overviewWidget/ProductInformation.jsx
@@ -43,7 +43,7 @@ class ProductInformation extends React.Component {
   render () {
     return (
       <div className="product-information">
-        <StarAverage reviewAverage={this.props.reviewAverage}/>{' '}<a href="/"><small>{`Read all ${this.state.reviewCount} reviews`}</small></a>
+        <StarAverage reviewAverage={this.props.reviewAverage}/>{' '}<a href="#anchor"><small>{`Read all ${this.state.reviewCount} reviews`}</small></a>
         <div className="item-category">{this.props.product.category}</div>
         <div className="product-name">{this.props.product.name}</div>
         {this.state.salePrice ? <div><span style={{textDecoration: 'line-through'}}>${this.state.defaultPrice}</span><span style={{color: 'red'}}> ${this.state.salePrice}</span></div> : <div>${this.state.defaultPrice}</div>}

--- a/client/components/overviewWidget/ProductInformation.jsx
+++ b/client/components/overviewWidget/ProductInformation.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import StarAverage from '../shared/StarAverage.jsx';
 import axios from 'axios';
-import './styles/OverviewStyles.scss';
 
 class ProductInformation extends React.Component {
   constructor(props) {

--- a/client/components/overviewWidget/ProductInformation.jsx
+++ b/client/components/overviewWidget/ProductInformation.jsx
@@ -43,7 +43,7 @@ class ProductInformation extends React.Component {
   render () {
     return (
       <div className="product-information">
-        <StarAverage />{' '}<a href="/"><small>{`Read all ${this.state.reviewCount} reviews`}</small></a>
+        <StarAverage reviewAverage={this.props.reviewAverage}/>{' '}<a href="/"><small>{`Read all ${this.state.reviewCount} reviews`}</small></a>
         <div className="item-category">{this.props.product.category}</div>
         <div className="product-name">{this.props.product.name}</div>
         {this.state.salePrice ? <div><span style={{textDecoration: 'line-through'}}>${this.state.defaultPrice}</span><span style={{color: 'red'}}> ${this.state.salePrice}</span></div> : <div>${this.state.defaultPrice}</div>}

--- a/client/components/overviewWidget/ProductOverview.jsx
+++ b/client/components/overviewWidget/ProductOverview.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import axios from 'axios';
 import ProductFeatures from './ProductFeatures.jsx';
-import './styles/OverviewStyles.scss';
 
 class ProductOverview extends React.Component {
   constructor(props) {

--- a/client/components/overviewWidget/StyleSelector.jsx
+++ b/client/components/overviewWidget/StyleSelector.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Styles from './Styles.jsx';
 import axios from 'axios';
-import './styles/OverviewStyles.scss';
 
 class StyleSelector extends React.Component {
   constructor(props) {

--- a/client/components/overviewWidget/Styles.jsx
+++ b/client/components/overviewWidget/Styles.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import './styles/OverviewStyles.scss';
 
 class Styles extends React.Component {
   constructor(props) {

--- a/public/styles.scss
+++ b/public/styles.scss
@@ -8,4 +8,5 @@ $border: 4px solid black;
 @import '../client/components/reviewWidget/breakdownComponents/styles/reviewBar.scss';
 @import './carousel';
 @import '../client/components/QnAs/QnAs.scss';
-@import '../client/components/reviewWidget/breakdownComponents/styles/characteristicScale.scss'
+@import '../client/components/reviewWidget/breakdownComponents/styles/characteristicScale.scss';
+@import '../client/components/overviewWidget/styles/OverviewStyles.scss';


### PR DESCRIPTION
No major changes here. Ran into quite the brick wall in making anymore major progress, unfortunately, with both advanced styling/animations/features and testing. 

As far as not huge but still significant changes:

I added an anchor tag around ReviewsWidget.jsx heading3 element, along with a link in my widget, that makes the page go to the ReviewsWidget portion of the page when the user clicks on "See all [#] reviews" in Overview Widget. I checked with Colin on this and he was okay with me adding that modification to his file.

Made Review Stars Average icon in Product Information Component (the stars at the top right of the app) dynamically fill with actual review average (i.e. if average rating 4.5, 4.5 stars colored in).

Also took out scss file import statement from Overview and put it in proper place in styles.scss.

Other than that, little cleanup.