### PR TITLE
Fixed the tests after styling

### DIFF
--- a/client/components/App.test.js
+++ b/client/components/App.test.js
@@ -7,6 +7,7 @@ import ReviewsWidget from './ReviewsWidget.jsx';
 import Overview from './Overview';
 import QnAs from './QnAs/QnAs.jsx';
 import RelatedProducts from './RelatedProducts';
+import BrowserRouter from 'react-router-dom';
 
 describe('App should ', () => {
   let app;
@@ -48,19 +49,19 @@ describe('App should ', () => {
   });
 
   test('render the Overview Widget', () => {
-    expect(app.containsAnyMatchingElements([Overview])).toEqual(true);
+    expect(app.find('Overview').length).toEqual(1);
   });
 
   test('render the Related Products Widget', () => {
-    expect(app.containsAnyMatchingElements([RelatedProducts])).toEqual(true);
+    expect(app.find('RelatedProducts').length).toEqual(1);
   });
 
   test('render the Questions & Answers Widget', () => {
-    expect(app.containsAnyMatchingElements([QnAs])).toEqual(true);
+    expect(app.find('QnAs').length).toEqual(1);
   });
 
   test('render the Reviews Widget', () => {
-    expect(app.containsAnyMatchingElements([ReviewsWidget])).toEqual(true);
+    expect(app.find('ReviewsWidget').length).toEqual(1);
   });
 
 });

--- a/client/components/reviewWidget/__tests__/breakdownComp.test.js
+++ b/client/components/reviewWidget/__tests__/breakdownComp.test.js
@@ -26,7 +26,6 @@ describe('ReviewSummary', () => {
   });
 
   test('should display reviewAverage with 1 decimal place', () => {
-    debugger;
     let renderedAverage = component.find('#review-average').render()[0].children[0].data;
     expect(renderedAverage).toEqual('3.5');
   });

--- a/client/components/reviewWidget/__tests__/breakdownComp.test.js
+++ b/client/components/reviewWidget/__tests__/breakdownComp.test.js
@@ -26,7 +26,8 @@ describe('ReviewSummary', () => {
   });
 
   test('should display reviewAverage with 1 decimal place', () => {
-    let renderedAverage = component.find('.review-average').render()[0].children[0].data;
+    debugger;
+    let renderedAverage = component.find('#review-average').render()[0].children[0].data;
     expect(renderedAverage).toEqual('3.5');
   });
 


### PR DESCRIPTION
One of my tests was failing because I changed the classname to an id, fixed that.

The App.js tests were also all failing and I'm still stumped as to why but I found that using the .find() method and using the name of the component as a string ex app.('ReviewWidget') was working so I just used that to test the presence of components.