### PR TITLE
145 react router

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -64,7 +64,15 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    this.getNewProduct(11001);
+    let productId = this.props.location.pathname.slice(1) || 11001;
+    this.getNewProduct(productId);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      let productId = this.props.location.pathname.slice(1) || 11001;
+      this.getNewProduct(productId);
+    }
   }
 
   addToOutfit() {
@@ -93,7 +101,6 @@ class App extends React.Component {
 
   render () {
     return (
-      // <BrowserRouter>
         <div>
           <Overview
             product={this.state.product}
@@ -120,7 +127,6 @@ class App extends React.Component {
             reviewCount={this.state.reviewCount}
           />
         </div>
-      // </BrowserRouter>
     );
   }
 }

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -5,17 +5,12 @@ import RelatedProducts from './RelatedProducts.jsx';
 import QnAs from './QnAs/QnAs.jsx';
 import RatingsAndReviews from './ReviewsWidget.jsx';
 import { sumReviewCount, calculateReviewAverage } from '../helpers/reviewsHelpers';
-import {
-  BrowserRouter,
-  Switch,
-  Route,
-  Link
-} from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 
 class App extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       product: {
@@ -98,7 +93,7 @@ class App extends React.Component {
 
   render () {
     return (
-      <BrowserRouter>
+      // <BrowserRouter>
         <div>
           <Overview
             product={this.state.product}
@@ -125,7 +120,7 @@ class App extends React.Component {
             reviewCount={this.state.reviewCount}
           />
         </div>
-      </BrowserRouter>
+      // </BrowserRouter>
     );
   }
 }

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -5,7 +5,7 @@ import RelatedProducts from './RelatedProducts.jsx';
 import QnAs from './QnAs/QnAs.jsx';
 import RatingsAndReviews from './ReviewsWidget.jsx';
 import { sumReviewCount, calculateReviewAverage } from '../helpers/reviewsHelpers';
-import { BrowserRouter } from 'react-router-dom';
+import { withRouter } from 'react-router-dom';
 
 
 class App extends React.Component {
@@ -125,4 +125,4 @@ class App extends React.Component {
   }
 }
 
-export default App;
+export default withRouter(App);

--- a/client/components/relatedWidget/ProductListItem.jsx
+++ b/client/components/relatedWidget/ProductListItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import StarAverage from '../shared/StarAverage.jsx';
-import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import ActionButton from './ActionButton.jsx';
 
 class ProductListItem extends React.Component {
@@ -11,12 +11,6 @@ class ProductListItem extends React.Component {
   render() {
     var page = '/' + this.props.text.id;
     return (
-      // <div
-      //   onClick={()=>{
-      //     this.props.getNewProduct(this.props.text.id);
-      //   }}
-      //  className={'menu-item'}
-      // >
       <div className={'menu-item'}>
         <h4>{this.props.text.category}</h4>
         <Link exact to={page}>
@@ -30,8 +24,6 @@ class ProductListItem extends React.Component {
           productId={this.props.text.id}
         />
       </div>
-
-      // <Route component={Home} />
     );
   }
 }

--- a/client/components/relatedWidget/ProductListItem.jsx
+++ b/client/components/relatedWidget/ProductListItem.jsx
@@ -1,40 +1,36 @@
 import React from 'react';
 import StarAverage from '../shared/StarAverage.jsx';
-import {
-  BrowserRouter as Router,
-  Switch,
-  Route,
-  NavLink
-} from "react-router-dom";
+import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
 import ActionButton from './ActionButton.jsx';
-
 
 class ProductListItem extends React.Component {
   constructor(props) {
     super(props);
   }
 
-  render () {
-    var page = '/'+this.props.text.id;
+  render() {
+    var page = '/' + this.props.text.id;
     return (
-      <NavLink exact to={page}>
-        <div
-          onClick={()=>{
-            this.props.getNewProduct(this.props.text.id);
-          }}
-         className={'menu-item'}
-        >
+      // <div
+      //   onClick={()=>{
+      //     this.props.getNewProduct(this.props.text.id);
+      //   }}
+      //  className={'menu-item'}
+      // >
+      <div className={'menu-item'}>
         <h4>{this.props.text.category}</h4>
-        <h4>{this.props.text.name}</h4>
-        <img src={this.props.image} width='200' height='250'/>
+        <Link exact to={page}>
+          <h4>{this.props.text.name}</h4>
+        </Link>
+        <img src={this.props.image} width="200" height="250" />
         <h4>${this.props.text.default_price}</h4>
-        <StarAverage reviewAverage={this.props.stars}/>
+        <StarAverage reviewAverage={this.props.stars} />
         <ActionButton
           buttonCallback={this.props.buttonCallback}
           productId={this.props.text.id}
         />
       </div>
-      </NavLink>
+
       // <Route component={Home} />
     );
   }

--- a/client/index.js
+++ b/client/index.js
@@ -5,7 +5,7 @@ import '../public/styles.scss';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
 
 ReactDOM.render(
-  <BrowserRouter forceRefresh={true}>
+  <BrowserRouter /* forceRefresh={true} */>
     <Switch>
       <Route path="/p/:productId" component={App} />
       <Route path="/" component={App} />

--- a/client/index.js
+++ b/client/index.js
@@ -2,6 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/App.jsx';
 import '../public/styles.scss';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Switch, Route } from 'react-router-dom';
 
-ReactDOM.render(<BrowserRouter><App /></BrowserRouter>, document.getElementById('app'));
+ReactDOM.render(
+  <BrowserRouter forceRefresh={true}>
+    <Switch>
+      <Route path="/p/:productId" component={App} />
+      <Route path="/" component={App} />
+    </Switch>
+  </BrowserRouter>,
+  document.getElementById('app')
+);

--- a/client/index.js
+++ b/client/index.js
@@ -2,5 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './components/App.jsx';
 import '../public/styles.scss';
+import { BrowserRouter } from 'react-router-dom';
 
-ReactDOM.render(<App />, document.getElementById('app'));
+ReactDOM.render(<BrowserRouter><App /></BrowserRouter>, document.getElementById('app'));

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ]
   },
   "scripts": {
-    "start": "server/index.js",
+    "start": "node server/index.js",
     "start-dev": "nodemon --inspect server/index.js",
     "build": "webpack --mode production --devtool none",
     "watch": "webpack -w",

--- a/public/_carousel.scss
+++ b/public/_carousel.scss
@@ -4,7 +4,7 @@
   padding: 0 40px;
   margin: 10px 10px;
   user-select: none;
-  cursor: pointer;
+  // cursor: pointer;
   border: 5px black solid;
 
   .add-button {

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <header>Sphinx</header>
-  <div id="app">If you can see this, React isn't running!</div>
+  <div id="app"></div>
   <script src="app.js"></script>
 </body>
 </html>

--- a/server/server.js
+++ b/server/server.js
@@ -1,3 +1,4 @@
+'use strict';
 const express = require('express');
 const path = require('path');
 const proxy = require('express-http-proxy');
@@ -10,10 +11,17 @@ const proxyOptions = {
   proxyReqOptDecorator: (proxyReqOpts, srcReq) => {
     proxyReqOpts.headers['Authorization'] = API_TOKEN;
     return proxyReqOpts;
+  },
+  proxyReqPathResolver: (req) => {
+    let url = req.url;
+    return '/api' + url;
   }
 };
 
 app.use(express.static(path.join(__dirname, '../public')));
-app.use('/', proxy(ATELIER_HOST, proxyOptions));
+app.use('/api', proxy(ATELIER_HOST, proxyOptions));
+app.use((req, res, next) => { // Catch all route that returns react app
+  res.sendFile(path.join(__dirname, '..', 'public', 'index.html'));
+});
 
 module.exports = app;


### PR DESCRIPTION
Refactored the react-router implementation so that product id state is driven by the url.  Please do download and test this out before merging to make sure it is still working correctly.  Now when you click on the name of a related product it will change the url to '/productNumber' for example 'localhost:3000/11003'.  The app now receives the url path and uses that to fetch the product id.  You should now be able to directly type in a url like 'http://localhost:3000/11003' in to the browser and the appropriate product should show up.

Closes #55 
